### PR TITLE
Add toString() to ErrFlow and notifier classes

### DIFF
--- a/lib/src/errflow.dart
+++ b/lib/src/errflow.dart
@@ -108,16 +108,36 @@ class ErrFlow<T> {
   /// as the message of an exception and the stack trace to the console.
   void useDefaultLogger() {
     assert(_debugAssertNotDisposed());
+    logger = _defaultLogger;
+  }
 
-    logger = (dynamic exception, StackTrace stack, {dynamic context}) {
-      print(exception);
-      if (stack != null) {
-        print(stack);
-      }
-      if (context != null) {
-        print(context);
-      }
-    };
+  void _defaultLogger(dynamic exception, StackTrace stack, {dynamic context}) {
+    print(exception);
+    if (stack != null) {
+      print(stack);
+    }
+    if (context != null) {
+      print(context);
+    }
+  }
+
+  @override
+  String toString() {
+    if (_notifier == null) {
+      return '$runtimeType#$hashCode';
+    }
+
+    final hasErrorHandler = errorHandler != null;
+    final hasCriticalErrorHandler = criticalErrorHandler != null;
+    final hasLogger = logger != null;
+    final loggerType = logger == _defaultLogger ? 'default' : 'custom';
+
+    return '$runtimeType#$hashCode('
+        'listeners: ${_notifier.countListeners()}, '
+        'defaultValue: ${_notifier.defaultValue}, '
+        'errorHandler: ${hasErrorHandler ? 'set' : 'null'}, '
+        'criticalErrorHandler: ${hasCriticalErrorHandler ? 'set' : 'null'}, '
+        'logger: ${hasLogger ? loggerType : 'null'})';
   }
 
   /// Executes the provided function [process], and then calls either of

--- a/lib/src/notifier_impl.dart
+++ b/lib/src/notifier_impl.dart
@@ -19,6 +19,17 @@ class _State<T> {
     assert(_listeners != null);
     _listeners.remove(listener);
   }
+
+  int countListeners() {
+    assert(_listeners != null);
+    return _listeners.length;
+  }
+
+  String _toString(Type type) {
+    return '$type#$hashCode('
+        'listeners: ${_listeners == null ? 'null' : countListeners()}, '
+        'lastError: $lastError)';
+  }
 }
 
 class Notifier<T> with _State<T> implements ErrNotifier<T> {
@@ -38,6 +49,7 @@ class Notifier<T> with _State<T> implements ErrNotifier<T> {
   }
 
   final T _defaultValue;
+  T get defaultValue => _defaultValue;
 
   @override
   void set(T error, [dynamic exception, StackTrace stack, dynamic context]) {
@@ -64,6 +76,9 @@ class Notifier<T> with _State<T> implements ErrNotifier<T> {
       listener(exception: exception, stack: stack, context: context);
     }
   }
+
+  @override
+  String toString() => _toString((<T>() => T)<ErrNotifier<T>>());
 }
 
 class LoggingNotifier<T> with _State<T> implements LoggingErrNotifier<T> {
@@ -98,6 +113,9 @@ class LoggingNotifier<T> with _State<T> implements LoggingErrNotifier<T> {
       listener(exception: exception, stack: stack, context: context);
     }
   }
+
+  @override
+  String toString() => _toString((<T>() => T)<LoggingErrNotifier<T>>());
 }
 
 class IgnorableNotifier<T> with _State<T> implements IgnorableErrNotifier<T> {
@@ -117,4 +135,7 @@ class IgnorableNotifier<T> with _State<T> implements IgnorableErrNotifier<T> {
 
   @override
   void log(dynamic exception, [StackTrace stack, dynamic context]) {}
+
+  @override
+  String toString() => _toString((<T>() => T)<IgnorableErrNotifier<T>>());
 }


### PR DESCRIPTION
Results of `print()`:

ErrFlow
```
ErrFlow<ErrorTypes>#53394082(listeners: 1, defaultValue: ErrorTypes.none, errorHandler: null, criticalErrorHandler: set, logger: custom)
```

ErrFlow (after `dispose()`)
```
ErrFlow<ErrorTypes>#53394082
```

ErrNotifier & LoggingErrNotifier
```
ErrNotifier<ErrorTypes>#535343788(listeners: 1, lastError: ErrorTypes.none)
LoggingErrNotifier<ErrorTypes>#58360420(listeners: 1, lastError: ErrorTypes.none)
```

IgnorableNotifier
```
IgnorableErrNotifier<ErrorTypes>#654520861(listeners: null, lastError: ErrorTypes.none)
```