### PR TITLE
Add hasError to each notifier class

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ final result = await errFlow.scope<bool>(
 );
 ```
 
-The handler functions receive the result and the error value, which means you can combine them
-to customise the conditions for your preference.
+The handler functions receive the function result and the error value, which means you can
+combine them to customise the conditions for your preference.
 
-e.g. To make the `onError` handler called when the process fails for reasons other than a
+e.g. To trigger the `onError` handler when the process fails for reasons other than a
 connection error:
 
 ```dart
@@ -127,7 +127,7 @@ it, or ignore it completely.
 
 `notifier` passed from [loggingScope][logging-scope] is an object of
  [LoggingErrNotifier][logging-notifier]. Calls on that object to [set()][logging-set] are
-proxied to [log()][logging-log], meaning that the error handlers are not triggered.
+forwarded to [log()][logging-log], meaning that the error handlers are not triggered.
 
 ```dart
 await errFlow.loggingScope<bool>(

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Future<bool> yourMethod(ErrNotifier notifier) {
     notifier.log(e, s, 'additional info');
   }
 
+  // You can use hasError to check if some error was set. 
+  if (notifier.hasError) {
+    ...
+  }
+
   return false;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ final result = await errFlow.scope<bool>(
 The handler functions receive the function result and the error value, which means you can
 combine them to customise the conditions for your preference.
 
+e.g. To trigger the `onError` handler if any error was set:
+
+```dart
+errorIf: (result, error) => error != errFlow.defaultError
+```
+
 e.g. To trigger the `onError` handler when the process fails for reasons other than a
 connection error:
 

--- a/lib/src/errflow.dart
+++ b/lib/src/errflow.dart
@@ -208,7 +208,7 @@ class ErrFlow<T> {
   ///
   /// The object can be used to call [LoggingErrNotifier.set()] and
   /// [LoggingErrNotifier.log()], but calls to [LoggingErrNotifier.set()]
-  /// are proxied to the logger.
+  /// are forwarded to the logger.
   ///
   /// This is useful when you want errors set by [LoggingErrNotifier.set()]
   /// in [process] to be only logged instead of handled by the error

--- a/lib/src/errflow.dart
+++ b/lib/src/errflow.dart
@@ -64,6 +64,11 @@ class ErrFlow<T> {
   /// operations to Crashlytics..
   void Function(dynamic, StackTrace, {dynamic context}) logger;
 
+  /// A getter for the value that was set in the constructor and is used as
+  /// the initial value for [lastError] in an object of the [ErrNotifier]
+  /// class and its variants in each [scope()].
+  T get defaultValue => _notifier.defaultValue;
+
   bool _debugAssertNotDisposed() {
     assert(() {
       if (_notifier == null) {

--- a/lib/src/notifier.dart
+++ b/lib/src/notifier.dart
@@ -20,8 +20,9 @@ abstract class ErrNotifier<T> {
   /// The latest error value that was notified most recently.
   T get lastError;
 
-  /// Calls all the registered listeners with error information including
-  /// the error value, the exception, etc.
+  /// Sets [error] to [lastError], and then calls all the registered
+  /// listeners with the error passed in, along with related information
+  /// if provided.
   void set(T error, [dynamic exception, StackTrace stack, dynamic context]);
 
   /// Calls all the registered listeners with error information, but
@@ -29,11 +30,12 @@ abstract class ErrNotifier<T> {
   void log(dynamic exception, [StackTrace stack, dynamic context]);
 }
 
-/// A variant of [ErrNotifier] that proxies calls to the [set()] method
+/// A variant of [ErrNotifier] that forwards calls to the [set()] method
 /// to [log()].
 @sealed
 abstract class LoggingErrNotifier<T> extends ErrNotifier<T> {
-  /// Updates [lastError] and delegates the notification task to [log()].
+  /// Updates [lastError], and then calls [log()] instead of calling one of
+  /// the error handlers.
   @override
   void set(T error, [dynamic exception, StackTrace stack, dynamic context]);
 

--- a/lib/src/notifier.dart
+++ b/lib/src/notifier.dart
@@ -20,6 +20,10 @@ abstract class ErrNotifier<T> {
   /// The latest error value that was notified most recently.
   T get lastError;
 
+  /// Whether or not there was an error. `true` is returned if [lastError]
+  /// is not equal to the default value.
+  bool get hasError;
+
   /// Sets [error] to [lastError], and then calls all the registered
   /// listeners with the error passed in, along with related information
   /// if provided.

--- a/lib/src/notifier_impl.dart
+++ b/lib/src/notifier_impl.dart
@@ -39,13 +39,11 @@ class Notifier<T> with _State<T> implements ErrNotifier<T> {
     _lastError = defaultValue;
   }
 
-  factory Notifier.from(Notifier<T> notifier) {
+  Notifier.from(Notifier<T> notifier) : _defaultValue = notifier.defaultValue {
     assert(notifier._listeners != null);
 
-    return Notifier<T>(
-      notifier._defaultValue,
-      listeners: Set.of(notifier._listeners),
-    );
+    _listeners = Set.of(notifier._listeners);
+    _lastError = defaultValue;
   }
 
   final T _defaultValue;
@@ -82,18 +80,11 @@ class Notifier<T> with _State<T> implements ErrNotifier<T> {
 }
 
 class LoggingNotifier<T> with _State<T> implements LoggingErrNotifier<T> {
-  LoggingNotifier(T defaultValue, {Set<ErrListener<T>> listeners}) {
-    _listeners = listeners ?? {};
-    _lastError = defaultValue;
-  }
-
-  factory LoggingNotifier.from(Notifier<T> notifier) {
+  LoggingNotifier.from(Notifier<T> notifier) {
     assert(notifier._listeners != null);
 
-    return LoggingNotifier(
-      notifier._defaultValue,
-      listeners: Set.of(notifier._listeners),
-    );
+    _listeners = Set.of(notifier._listeners);
+    _lastError = notifier._defaultValue;
   }
 
   @override
@@ -119,12 +110,9 @@ class LoggingNotifier<T> with _State<T> implements LoggingErrNotifier<T> {
 }
 
 class IgnorableNotifier<T> with _State<T> implements IgnorableErrNotifier<T> {
-  IgnorableNotifier(T defaultValue) {
-    _lastError = defaultValue;
-  }
-
-  factory IgnorableNotifier.from(Notifier<T> notifier) {
-    return IgnorableNotifier(notifier._defaultValue);
+  IgnorableNotifier.from(Notifier<T> notifier) {
+    assert(notifier._listeners != null);
+    _lastError = notifier._defaultValue;
   }
 
   @override

--- a/lib/src/notifier_impl.dart
+++ b/lib/src/notifier_impl.dart
@@ -1,6 +1,6 @@
 import 'errflow.dart';
 
-class _State<T> {
+mixin _State<T> {
   Set<ErrListener<T>> _listeners;
   T _lastError;
 

--- a/lib/src/notifier_impl.dart
+++ b/lib/src/notifier_impl.dart
@@ -2,9 +2,12 @@ import 'errflow.dart';
 
 mixin _State<T> {
   Set<ErrListener<T>> _listeners;
+  T _defaultValue;
   T _lastError;
 
+  T get defaultValue => _defaultValue;
   T get lastError => _lastError;
+  bool get hasError => _lastError != _defaultValue;
 
   void dispose() {
     _lastError = _listeners = null;
@@ -33,21 +36,19 @@ mixin _State<T> {
 }
 
 class Notifier<T> with _State<T> implements ErrNotifier<T> {
-  Notifier(T defaultValue, {Set<ErrListener<T>> listeners})
-      : _defaultValue = defaultValue {
+  Notifier(T defaultValue, {Set<ErrListener<T>> listeners}) {
+    _defaultValue = defaultValue;
     _listeners = listeners ?? {};
     _lastError = defaultValue;
   }
 
-  Notifier.from(Notifier<T> notifier) : _defaultValue = notifier.defaultValue {
+  Notifier.from(Notifier<T> notifier) {
     assert(notifier._listeners != null);
 
+    _defaultValue = notifier.defaultValue;
     _listeners = Set.of(notifier._listeners);
-    _lastError = defaultValue;
+    _lastError = _defaultValue;
   }
-
-  final T _defaultValue;
-  T get defaultValue => _defaultValue;
 
   @override
   void set(T error, [dynamic exception, StackTrace stack, dynamic context]) {
@@ -83,8 +84,9 @@ class LoggingNotifier<T> with _State<T> implements LoggingErrNotifier<T> {
   LoggingNotifier.from(Notifier<T> notifier) {
     assert(notifier._listeners != null);
 
+    _defaultValue = notifier.defaultValue;
     _listeners = Set.of(notifier._listeners);
-    _lastError = notifier._defaultValue;
+    _lastError = _defaultValue;
   }
 
   @override
@@ -112,7 +114,9 @@ class LoggingNotifier<T> with _State<T> implements LoggingErrNotifier<T> {
 class IgnorableNotifier<T> with _State<T> implements IgnorableErrNotifier<T> {
   IgnorableNotifier.from(Notifier<T> notifier) {
     assert(notifier._listeners != null);
-    _lastError = notifier._defaultValue;
+
+    _defaultValue = notifier.defaultValue;
+    _lastError = _defaultValue;
   }
 
   @override

--- a/test/errflow_test.dart
+++ b/test/errflow_test.dart
@@ -13,6 +13,19 @@ void main() {
       );
     });
 
+    test('defaultValue has the default value set in constructor', () {
+      errFlow.scope<void>((notifier) async {
+        expect(errFlow.defaultValue, 100);
+      });
+    });
+
+    test('defaultValue does not change even if set() is called', () {
+      errFlow.scope<void>((notifier) async {
+        notifier.set(200);
+        expect(errFlow.defaultValue, 100);
+      });
+    });
+
     test('notifier in scope() has the default value', () async {
       await errFlow.scope<void>((notifier) async {
         notifier.set(200);

--- a/test/errflow_test.dart
+++ b/test/errflow_test.dart
@@ -7,11 +7,14 @@ void main() {
 
   group('function passed to scope()', () {
     test('assert() fails if the function is null', () {
-      expect(() => errFlow.scope<void>(null), throwsA(isA<AssertionError>()));
+      expect(
+        () => errFlow.scope<void>(null),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
-    test('notifier provided by scope() has the default value', () {
-      errFlow.scope<void>((notifier) async {
+    test('notifier in scope() has the default value', () async {
+      await errFlow.scope<void>((notifier) async {
         notifier.set(200);
       });
 
@@ -334,6 +337,38 @@ void main() {
       errFlow.ignorableScope<void>((notifier) async {
         expect(notifier, isA<IgnorableErrNotifier>());
       });
+    });
+
+    test('notifier in loggingScope() has the default value', () async {
+      await errFlow.loggingScope<void>((notifier) async {
+        notifier.set(200);
+      });
+
+      errFlow.loggingScope<void>((notifier) async {
+        expect(notifier.lastError, 100);
+      });
+    });
+
+    test('notifier in ignorableScope() has the default value', () async {
+      await errFlow.ignorableScope<void>((notifier) async {
+        notifier.set(200);
+      });
+
+      errFlow.ignorableScope<void>((notifier) async {
+        expect(notifier.lastError, 100);
+      });
+    });
+  });
+
+  group('dispose', () {
+    final errFlow2 = ErrFlow<int>(100);
+    errFlow2.dispose();
+
+    test('calling toString() after dispose() causes no error', () {
+      expect(
+        () => errFlow2.toString(),
+        isNot(throwsA(isA<AssertionError>())),
+      );
     });
   });
 }

--- a/test/errflow_test.dart
+++ b/test/errflow_test.dart
@@ -49,6 +49,14 @@ void main() {
       );
       expect(result, 200);
     });
+
+    test('hasError returns an appropriate value', () {
+      errFlow.scope<void>((notifier) async {
+        expect(notifier.hasError, false);
+        notifier.set(200);
+        expect(notifier.hasError, true);
+      });
+    });
   });
 
   group('errorIf / onError', () {
@@ -369,6 +377,22 @@ void main() {
 
       errFlow.ignorableScope<void>((notifier) async {
         expect(notifier.lastError, 100);
+      });
+    });
+
+    test('hasError returns an appropriate value in loggingScope', () {
+      errFlow.loggingScope<void>((notifier) async {
+        expect(notifier.hasError, false);
+        notifier.set(200);
+        expect(notifier.hasError, true);
+      });
+    });
+
+    test('hasError returns an appropriate value in loggingScope', () {
+      errFlow.ignorableScope<void>((notifier) async {
+        expect(notifier.hasError, false);
+        notifier.set(200);
+        expect(notifier.hasError, true);
       });
     });
   });

--- a/test/info_test.dart
+++ b/test/info_test.dart
@@ -63,6 +63,14 @@ void main() {
       expect(notification1.errors, <int>[1, 2]);
       expect(notification2.errors, <int>[2, 3]);
     });
+
+    test('hasError returns an appropriate value', () {
+      final newNotifier = Notifier<int>(10);
+      expect(newNotifier.hasError, false);
+
+      newNotifier.set(1);
+      expect(newNotifier.hasError, true);
+    });
   });
 
   group('LoggingErrNotifier', () {
@@ -102,6 +110,14 @@ void main() {
       expect(notification.stacks, ['bar']);
       expect(notification.contexts, ['baz']);
     });
+
+    test('hasError returns an appropriate value', () {
+      final newLoggingNotifier = LoggingNotifier<int>.from(notifier);
+      expect(newLoggingNotifier.hasError, false);
+
+      newLoggingNotifier.set(1);
+      expect(newLoggingNotifier.hasError, true);
+    });
   });
 
   group('IgnorableErrNotifier', () {
@@ -123,6 +139,14 @@ void main() {
     test('calling set() does not update last error in original object', () {
       ignorableNotifier.set(1);
       expect(notifier.lastError, 10);
+    });
+
+    test('hasError returns an appropriate value', () {
+      final newIgnorableNotifier = IgnorableNotifier<int>.from(notifier);
+      expect(newIgnorableNotifier.hasError, false);
+
+      newIgnorableNotifier.set(1);
+      expect(newIgnorableNotifier.hasError, true);
     });
   });
 

--- a/test/info_test.dart
+++ b/test/info_test.dart
@@ -11,7 +11,10 @@ void main() {
     });
 
     test('assert() fails if set() is called without error value', () {
-      expect(() => notifier.set(null), throwsA(isA<AssertionError>()));
+      expect(
+        () => notifier.set(null),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('calling set() updates last error', () {
@@ -60,18 +63,6 @@ void main() {
       expect(notification1.errors, <int>[1, 2]);
       expect(notification2.errors, <int>[2, 3]);
     });
-
-    test('cannot be used after disposed', () {
-      final notification = _Notification();
-
-      notifier
-        ..addListener(notification.listener)
-        ..set(1)
-        ..dispose();
-
-      expect(notification.errors, <int>[1]);
-      expect(() => notifier.set(2), throwsA(isA<AssertionError>()));
-    });
   });
 
   group('LoggingErrNotifier', () {
@@ -88,7 +79,7 @@ void main() {
       expect(notifier.lastError, 10);
     });
 
-    test('a call to set() is proxied to log()', () {
+    test('a call to set() is forwarded to log()', () {
       final notification = _Notification();
       loggingNotifier
         ..addListener(notification.listener)
@@ -132,6 +123,28 @@ void main() {
     test('calling set() does not update last error in original object', () {
       ignorableNotifier.set(1);
       expect(notifier.lastError, 10);
+    });
+  });
+
+  group('dispose', () {
+    final notifier = Notifier<int>(10);
+    final notification = _Notification();
+
+    notifier
+      ..addListener(notification.listener)
+      ..set(1)
+      ..dispose();
+
+    test('cannot be used after disposed', () {
+      expect(notification.errors, <int>[1]);
+      expect(() => notifier.set(2), throwsA(isA<AssertionError>()));
+    });
+
+    test('calling toString() after dispose() causes no error', () {
+      expect(
+        () => notifier.toString(),
+        isNot(throwsA(isA<AssertionError>())),
+      );
     });
   });
 }


### PR DESCRIPTION
`hasError` is added to `ErrNotifier`, `LoggingErrNotifier` and `IgnorableErrNotifier`.
This makes it a little easier to check if an error occurred in a scope.

- Without hasError

```dart
errFlow.scope<void>(
  (notifier) async {
    if (notifier.lastError != errFlow.defaultValue) {
      ...
    }
  },
  errorIf: (result, error) => ...,
}
```

- With hasError

```dart
errFlow.scope<void>(
  (notifier) async {
    if (notifier.hasError) {
      ...
    }
  },
  errorIf: (result, error) => ...,
}
```
