### PR TITLE
Change the logger signature in accordance with the new api of firebase_crashlytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ errFlow.useDefaultLogger();
 If it lacks functionality you need, set your own logger.
 
 ```dart
-void _logger(dynamic e, StackTrace s, {dynamic context}) {
+Future<void> _logger(dynamic e, StackTrace s, {dynamic reason}) async {
   // Logging operations
 }
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -23,7 +23,7 @@ Future<void> main() async {
   errFlow.dispose();
 }
 
-void logger(dynamic e, StackTrace s, {dynamic context}) {
+Future<void> logger(dynamic e, StackTrace s, {dynamic reason}) async {
   print('Logged: $e');
 }
 

--- a/lib/src/errflow.dart
+++ b/lib/src/errflow.dart
@@ -30,7 +30,7 @@ class ErrFlow<T> {
           );
 
           if (logger != null && exception != null) {
-            logger(exception, stack, context: context);
+            logger(exception, stack, reason: context);
           }
         },
       );
@@ -59,10 +59,11 @@ class ErrFlow<T> {
   /// A logger function that is called when an error is notified.
   ///
   /// The signature matches that of the `recordError()` method in the
-  /// official `firebase_crashlytics` plugin package, and thus the method
-  /// can be assigned to this logger as is, if you want to leave logging
-  /// operations to Crashlytics..
-  void Function(dynamic, StackTrace, {dynamic context}) logger;
+  /// `firebase_crashlytics` package (although this logger does not have
+  /// some named parameters existing in `recordError()`), and thus the
+  /// `FirebaseCrashlytics.recordError` can be assigned to the logger as is
+  /// if you want to leave logging operations to Crashlytics.
+  Future<void> Function(dynamic, StackTrace, {dynamic reason}) logger;
 
   /// A getter for the value that was set in the constructor and is used as
   /// the initial value for [lastError] in an object of the [ErrNotifier]
@@ -116,13 +117,14 @@ class ErrFlow<T> {
     logger = _defaultLogger;
   }
 
-  void _defaultLogger(dynamic exception, StackTrace stack, {dynamic context}) {
+  Future<void> _defaultLogger(dynamic exception, StackTrace stack,
+      {dynamic reason}) async {
     print(exception);
     if (stack != null) {
       print(stack);
     }
-    if (context != null) {
-      print(context);
+    if (reason != null) {
+      print(reason);
     }
   }
 

--- a/test/errflow_test.dart
+++ b/test/errflow_test.dart
@@ -293,7 +293,7 @@ void main() {
         notifier.log('foo', _StackTrace('bar'), 'baz');
         expect(log.exception, 'foo');
         expect(log.stack.toString(), 'bar');
-        expect(log.context, 'baz');
+        expect(log.reason, 'baz');
       });
     });
 
@@ -305,7 +305,7 @@ void main() {
         notifier.log('foo', _StackTrace('bar'));
         expect(log.exception, 'foo');
         expect(log.stack.toString(), 'bar');
-        expect(log.context, isNull);
+        expect(log.reason, isNull);
       });
     });
 
@@ -317,7 +317,7 @@ void main() {
         notifier.set(200, 'foo', _StackTrace('bar'), 'baz');
         expect(log.exception, 'foo');
         expect(log.stack.toString(), 'bar');
-        expect(log.context, 'baz');
+        expect(log.reason, 'baz');
       });
     });
 
@@ -413,12 +413,12 @@ void main() {
 class _Log {
   dynamic exception;
   StackTrace stack;
-  dynamic context;
+  dynamic reason;
 
-  void logger(dynamic e, StackTrace s, {dynamic context}) {
+  Future<void> logger(dynamic e, StackTrace s, {dynamic reason}) async {
     exception = e;
     stack = s;
-    this.context = context;
+    this.reason = reason;
   }
 }
 


### PR DESCRIPTION
firebase_crashlytics v0.2.0 was released a few days ago. The `recordError()` method of the package has changed as follows:

Before
```
Future<void> recordError(dynamic exception, StackTrace stack, {dynamic context})
```

Now (>= 0.2.0)
```
Future<void> recordError(dynamic exception, StackTrace stack, {dynamic reason, Iterable<DiagnosticsNode> information, bool printDetails})
```

This PR renames `context` to `reason` in accordance with the above change, but does not add `information` and `printDetails`.

- Iterable\<DiagnosticsNode\> information
    - `DiagnosticsNode` is defined in Flutter, which errflow should avoid depending on.
- bool printDetails
    - This flag just switches on/off the output of detailed information to the console.
    - If not specified, printing is automatically enabled on the debug mode, otherwise disabled.
        - This default behaviour seems sufficient. errflow doesn't have to support the parameter.

---

Another improvement/fix is the returned type.
It was `void` in the previous logger, but is now `Future<void>` as `recordError()` has consistently returned `Future<void>` in both old and new APIs.
